### PR TITLE
adaptação do layout para o iPhone X

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ DEPENDENCIES
   jekyll (= 3.3.1)
 
 RUBY VERSION
-   ruby 2.3.1p112
+   ruby 2.3.3p222
 
 BUNDLED WITH
-   1.13.6
+   1.15.1

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,7 +2,7 @@
    <meta charset="UTF-8">
    <title>{{ site.name }}</title>
 
-   <meta name="viewport" content="width=device-width, initial-scale=1">
+   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
    <meta name="author" content="{{ site.name }}">
    <meta property="og:type" content="website">
    <meta property="og:url" content="{{ site.url }}">

--- a/_sass/constants.scss
+++ b/_sass/constants.scss
@@ -11,3 +11,4 @@ $description-font-size: 0.85em;
 $font-size: 15px;
 
 $small-screen-breakpoint: 50em;
+$smaller-screen-breakpoint: 928px; // px count where personal info shrinks too much

--- a/css/category.scss
+++ b/css/category.scss
@@ -13,6 +13,7 @@
         border-bottom: 1px solid;
         text-transform: uppercase;
         font-weight: bold;
+        border-bottom-color: $highlight-color;
     }
 
     .item-icon {
@@ -71,39 +72,6 @@
     text-align: right;
     padding-right: 10px;
     border-right: 1px black solid;
-
-/**
-    .date-container, .triangle-container {
-        display: inline;
-    }
-
-    .date-container {
-        background-color: $left-color;
-        color: $left-font-color;
-    }
-
-    .triangle-container {
-        * {
-            width: 0;
-            height: 0;
-            font-size: 0;
-        }
-
-        .top-triangle {
-            border-bottom: 5px solid black;
-            border-right: 5px solid transparent;
-            border-left: 5px solid black;
-            border-top: 5px solid transparent;
-        }
-
-        .bottom-triangle {
-            border-bottom: 5px solid transparent;
-            border-right: 5px solid transparent;
-            border-left: 5px solid black;
-            border-top: 5px solid black;
-        }
-    }
-    **/
 }
 
 .exp-level {

--- a/css/print.scss
+++ b/css/print.scss
@@ -37,6 +37,9 @@ a {
 
     .category {
         margin-top: 10px;
+        .category-title {
+            border-bottom-color: $print-font-color;
+        }
     }
 
     #personal-panel {

--- a/css/screen.scss
+++ b/css/screen.scss
@@ -16,7 +16,7 @@
 #personal-panel, #small-info-panel {
     background-color: $left-color;
     color: $left-font-color;
-
+    padding-left: constant(safe-area-inset-left);
     svg {
         fill: $left-font-color;
     }
@@ -25,6 +25,7 @@
 #professional-panel {
     background-color: $right-color;
     color: $right-font-color;
+    padding-right: constant(safe-area-inset-right);
 }
 
 a {
@@ -35,10 +36,6 @@ a {
     border-color: $highlight-color;
 }
 
-// TODO Arrumar um jeito de fazer isso sem !important
-.category-title {
-    border-bottom-color: $highlight-color !important;
-}
 
 .exp-level .dot {
     border: 1px $highlight-color solid;
@@ -71,6 +68,13 @@ a {
     }
 }
 
+@media(max-width: $smaller-screen-breakpoint) {
+    #personal-panel {
+        flex: 2 0 0;
+    }
+}
+
+
 @media (max-width: $small-screen-breakpoint) {
     #info-panel {
         display: none;
@@ -80,4 +84,5 @@ a {
         width: 40%;
         height: auto;
     }
+
 }


### PR DESCRIPTION
A página fica com o `background-color` original a mostra por conta do notch do iPhone X e o padding extra que o Safari adiciona no `body` para compensar a existência dele, mas isto não reflete corretamente o estilo da página

Layout antes das mudanças: (Notar que o espaço em branco faz parte da screenshot, apesar do fundo do GitHub fazer ele desaparecer)

![simulator screen shot - iphone x - 2017-09-15 at 01 55 07](https://user-images.githubusercontent.com/5796060/30467129-f812bfc2-99b8-11e7-8cbe-de6cc89edfa9.png)

Layout após as mudanças:

![simulator screen shot - iphone x - 2017-09-15 at 01 51 03](https://user-images.githubusercontent.com/5796060/30467135-fadeb44a-99b8-11e7-8e2c-c150d58c7d78.png)